### PR TITLE
SRCH-3046 Move common elasticsearch service instructions from i14y to this repo's README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,15 @@ Database backend required by search-gov.
 ### [Elasticsearch](https://www.elastic.co/elasticsearch/)
 Services for Elasticsearch 6 and 7 are both provided here.
 
+Elasticsearch plugins:
+* [analysis-kuromoji](https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-kuromoji.html)
+* [analysis-icu](https://www.elastic.co/guide/en/elasticsearch/plugins/master/analysis-icu-analyzer.html)
+* [analysis-smartcn](https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-smartcn.html)
+
+Some specs depend upon Elasticsearch having a valid trial license. A 30-day trial license is automatically applied when the cluster is initially created. If your license expires, you can rebuild the cluster by [rebuilding the container and its data volume](https://github.com/GSA/search-gov/wiki/Docker-Command-Reference/_edit#recreate-an-elasticsearch-cluster-useful-for-restarting-a-trial-license). 
+
 #### Elasticsearch 6
-All of our applications use Elasticsearch 6 in production for full-text search. Locally, it runs on the default port [9200](http://localhost:9200/).
+All of our applications use Elasticsearch 6 in production for full-text search. Locally, it runs on the default port [9200](http://localhost:9200/). To use a different host (with or without port) or set of hosts, set the `ELASTICSEARCH_HOSTS` environment variable.
 
 **Please note: Elasticsearch 6 is not supported on M1 Macs.** Until all our repos use Elasticsearch 7 in mid-2022, Developers on M1s can run the remaining services with:
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Elasticsearch plugins:
 Some specs depend upon Elasticsearch having a valid trial license. A 30-day trial license is automatically applied when the cluster is initially created. If your license expires, you can rebuild the cluster by [rebuilding the container and its data volume](https://github.com/GSA/search-gov/wiki/Docker-Command-Reference/_edit#recreate-an-elasticsearch-cluster-useful-for-restarting-a-trial-license). 
 
 #### Elasticsearch 6
-All of our applications use Elasticsearch 6 in production for full-text search. Locally, it runs on the default port [9200](http://localhost:9200/). To use a different host (with or without port) or set of hosts, set the `ELASTICSEARCH_HOSTS` environment variable.
+All of our applications use Elasticsearch 6 in production for full-text search. Locally, it runs on the default port [9200](http://localhost:9200/).
 
 **Please note: Elasticsearch 6 is not supported on M1 Macs.** Until all our repos use Elasticsearch 7 in mid-2022, Developers on M1s can run the remaining services with:
 ```


### PR DESCRIPTION
## Summary
Related: https://github.com/GSA/i14y/pull/193

Moves common documentation language from [i14y](https://github.com/GSA/i14y/blob/main/README.md) into this repo's readme:
* Descriptions of elasticsearch plugins (now configured in search-services).
* Information on elasticsearch licesnses.
* Note about default elasticsearch port.

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Automated checks pass.

- [x] You have merged the latest changes from (usually `main`) into your branch.

~~- [ ] If your target branch is NOT `main`, specify the reason:~~

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number

- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop). N/A: using squash-and-merge.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket. N/A: using squash-and-merge.

#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers
