### PR TITLE
SRCH-3055 Remove ElasticSearch 6 from search-services

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,14 +68,6 @@ jobs:
               -timeout 90s
 
       - run:
-          name: 'Wait for Kibana 6'
-          command: |
-            docker run --network search-services_default docker.io/jwilder/dockerize \
-              -wait http://kibana6:5601 \
-              -wait-retry-interval 2s \
-              -timeout 90s
-
-      - run:
           name: 'Wait for Kibana 7'
           command: |
             docker run --network search-services_default docker.io/jwilder/dockerize \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,14 +60,6 @@ jobs:
               -timeout 30s
 
       - run:
-          name: 'Wait for Elasticsearch 6'
-          command: |
-            docker run --network search-services_default docker.io/jwilder/dockerize \
-              -wait http://elasticsearch6:9200 \
-              -wait-retry-interval 2s \
-              -timeout 90s
-
-      - run:
           name: 'Wait for Elasticsearch 7'
           command: |
             docker run --network search-services_default docker.io/jwilder/dockerize \

--- a/Dockerfile.elasticsearch7
+++ b/Dockerfile.elasticsearch7
@@ -1,5 +1,5 @@
-# searchgov/elasticsearch:7.17.3
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.3
+# searchgov/elasticsearch:7.17.7
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.7
 # The following plugins are required for multilingual support in i14y
 RUN elasticsearch-plugin install analysis-kuromoji
 RUN elasticsearch-plugin install analysis-icu

--- a/Dockerfile.elasticsearch8
+++ b/Dockerfile.elasticsearch8
@@ -1,5 +1,5 @@
-# searchgov/elasticsearch:6.8.23
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.8.23
+# searchgov/elasticsearch:8.5.3
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.5.3
 # The following plugins are required for multilingual support in i14y
 RUN elasticsearch-plugin install analysis-kuromoji
 RUN elasticsearch-plugin install analysis-icu

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ docker compose up
 ```
 Alternatively, you can run a subset of the services, i.e.:
 ```
-docker compose up mysql elasticsearch7
+docker compose up mysql elasticsearch7\
 ```
 
 Each repo uses one or more of the following services:
@@ -24,7 +24,7 @@ Each repo uses one or more of the following services:
 Database backend required by search-gov.
 
 ### [Elasticsearch](https://www.elastic.co/elasticsearch/)
-Services for Elasticsearch 6 and 7 are both provided here.
+Services for Elasticsearch 7 are provided here.
 
 Elasticsearch plugins:
 * [analysis-kuromoji](https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-kuromoji.html)
@@ -33,17 +33,8 @@ Elasticsearch plugins:
 
 Some specs depend upon Elasticsearch having a valid trial license. A 30-day trial license is automatically applied when the cluster is initially created. If your license expires, you can rebuild the cluster by [rebuilding the container and its data volume](https://github.com/GSA/search-gov/wiki/Docker-Command-Reference/_edit#recreate-an-elasticsearch-cluster-useful-for-restarting-a-trial-license). 
 
-#### Elasticsearch 6
-All of our applications use Elasticsearch 6 in production for full-text search. Locally, it runs on the default port [9200](http://localhost:9200/).
-
-**Please note: Elasticsearch 6 is not supported on M1 Macs.** Until all our repos use Elasticsearch 7 in mid-2022, Developers on M1s can run the remaining services with:
-```
-docker compose up mysql elasticsearch7 redis tika kibana7
-```
-You may also need to update the Elasticsearch host in each repo's `config/secrets.yml` or `config/elasticsearch.yml` file to specify `localhost:9207` to point to Elasticsearch 7.
-
 #### Elasticsearch 7
-Currently only used in development, running on port [9207](http://localhost:9207/).
+All of our applications use Elasticsearch 7 in production for full-text search. Locally, it runs on the default port [9200](http://localhost:9200/).
 
 ### [Redis](https://redis.io/)
 search-gov and ASIS use the Redis key-value store for caching, queue workflow via Resque (search-gov) and Sidekiq (ASIS), and some analytics. Optionally, you can install the [Redis CLI](https://redis.io/docs/manual/cli/).

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ docker compose up
 ```
 Alternatively, you can run a subset of the services, i.e.:
 ```
-docker compose up mysql elasticsearch7\
+docker compose up mysql elasticsearch7
 ```
 
 Each repo uses one or more of the following services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - 9200:9200
 
   kibana7:
-    image: docker.elastic.co/kibana/kibana:7.17.3
+    image: docker.elastic.co/kibana/kibana:7.17.7
     depends_on:
       - elasticsearch7
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,4 @@
 services:
-  elasticsearch6:
-    build:
-      context: ./
-      dockerfile: Dockerfile.elasticsearch6
-    environment:
-      - bootstrap.memory_lock=true
-      - cluster.name=es6-docker-cluster
-      - discovery.type=single-node
-      - xpack.license.self_generated.type=trial
-      - xpack.monitoring.enabled=false
-      - xpack.security.enabled=false
-      - 'ES_JAVA_OPTS=-Xms256m -Xmx256m'
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-    volumes:
-      - es_6_data:/usr/share/elasticsearch/data
-    ports:
-      - 9200:9200
-
   elasticsearch7:
     build:
       context: ./
@@ -39,23 +18,14 @@ services:
     volumes:
       - es_7_data:/usr/share/elasticsearch/data
     ports:
-      - 9207:9200
-
-  kibana6:
-    image: docker.elastic.co/kibana/kibana:6.8.23
-    depends_on:
-      - elasticsearch6
-    ports:
-      - 5601:5601
-    environment:
-      - ELASTICSEARCH_HOSTS=http://elasticsearch6:9200
+      - 9200:9200
 
   kibana7:
     image: docker.elastic.co/kibana/kibana:7.17.3
     depends_on:
       - elasticsearch7
     ports:
-      - 5607:5601
+      - 5601:5601
     environment:
       - ELASTICSEARCH_HOSTS=http://elasticsearch7:9200
 
@@ -83,5 +53,4 @@ services:
 
 volumes:
   db_data:
-  es_6_data:
   es_7_data:


### PR DESCRIPTION
## Summary
This PR removes ElasticSearch 6 from the Docker Compose configuration, making ElasticSearch 7 run on the default 9200 port. A Dockerfile has been created for ElasticSearch 8; full support for ElasticSearch 8 will be added in a follow-up PR.

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [x] You have merged the latest changes from (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number

- [x] Automated checks pass.

#### Process Checks

- [x] You have specified at least one "Reviewer".

