### PR TITLE
SRCH6225 Run Spider in Search Services

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
             git clone https://github.com/GSA/search-gov.git
             git clone https://github.com/GSA/i14y.git
             git clone https://github.com/GSA/asis.git
+            git clone https://github.com/GSA-TTS/searchgov-spider.git
             cd ~/workspace/search-services
 
       - run:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The docker-compose.yml file configures each service. You can refer to [Matrix](h
 | Application/Repo | Command | Profile name | Services |
 | --- | --- | --- | --- |
 |  | `docker compose up` | N/A | MySQL, Elasticsearch, Kibana, Redis, Tika |
-| search-gov |`docker compose --profile search-gov up` | search-gov | MySQL, Elasticsearch, Kibana, Redis, Tika, search-gov, resque-worker, resque-scheduler |
+| search-gov |`docker compose --profile search-gov up` | search-gov | MySQL, Elasticsearch, Kibana, Redis, Tika, search-gov, resque-worker, resque-scheduler, spider-scheduler, spider-sitemap |
 | i14y |`docker compose --profile i14y up` | i14y | MySQL, Elasticsearch, Kibana, Redis, Tika, i14y, resque-worker, resque-scheduler |
 | ASIS |`docker compose --profile asis up` | asis | MySQL, Elasticsearch, Kibana, Redis, Tika, asis, sidekiq |
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 This repo includes a centralized configuration for services used by Search.gov applications, including:
 
 - [search-gov](https://github.com/GSA/search-gov)
+- [spider](https://github.com/GSA-TTS/searchgov-spider)
 - [i14y](https://github.com/GSA/i14y)
 - [ASIS](https://github.com/GSA/asis)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,11 @@ services:
     networks:
       - app-network
     command: redis-server --bind "0.0.0.0"
+    healthcheck:
+      test: redis-cli ping >/dev/null || exit 1
+      interval: 1s
+      timeout: 3s
+      retries: 5
 
   opensearch:
     build:
@@ -281,6 +286,34 @@ services:
       - app-network
     profiles:
       - asis
+
+  spider:
+    &spider
+    build:
+      context: ../searchgov-spider
+      dockerfile: DockerFile.dev
+    env_file:
+      - ../searchgov-spider/.env.development
+    environment:
+      PYTHONPATH: /usr/src/searchgov-spider
+    depends_on:
+      redis:
+        condition: service_healthy
+      opensearch:
+        condition: service_healthy
+      elasticsearch7:
+        condition: service_healthy
+    network_mode: host
+    profiles:
+      - search-gov
+
+  spider-scheduler:
+    <<: *spider
+    command: python search_gov_crawler/scrapy_scheduler.py
+
+  spider-sitemap:
+    <<: *spider
+    command: python search_gov_crawler/run_sitemap_monitor.py
 
 volumes:
   db_data:


### PR DESCRIPTION
## Summary
- Related to GSA-TTS/searchgov-spider#334
- Adds the ability for spider to run with other search-services containers
- The two spider processes run in separate containers based on the same build.
- Updated docs to include spider.

## Testing
- The functionality of `docker compose up` remains the same
- To just start both spider containers and their dependent services (redis, es7, opensearch) e.g. use `docker compose up spider-scheduler spider-sitemap`
- I added the spider containers to the `search-gov` profile but I get (in main as well) an error about i14y: `service "resque-workers" depends on undefined service "i14y": invalid compose project` when I try to run `docker compose --profile search-gov up` but in theory spider should start as well when using this profile.
- To run an ad-hoc crawl check the spider docker quickstart readme or just run a command like `docker exec search-services-spider-scheduler-1 /bin/bash -c "spider crawl www.gsa.gov https://www.gsa.gov"` while the spider is up.

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [X] You have merged the latest changes from (usually `main`) into your branch.

- [X] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket

- [X] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number

- [x] Automated checks pass.  :warning: The tests will not pass until the spider PR is merged. :warning:

#### Process Checks

- [X] You have specified at least one "Reviewer".

