### PR TITLE
SRCH-6165 lock mysql version to 8.0.40

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
 
   mysql:
     platform: linux/amd64
-    image: mysql:8.0
+    image: mysql:8.0.40
     volumes:
       - db_data:/var/lib/mysql
     ports:


### PR DESCRIPTION
## Summary
- After upgrading our AWS resources to 8.0.40 we need to lock search-services to the same version.

### Testing
- Stop any currently running search-services docker containers
- On this branch run `docker compose up`
- The new mysql image should be downloaded
- You should not need to re-setup or migrate the database, all your data should still be there.
- You can verify the version by running the SQL `SHOW VARIABLES LIKE 'version';`

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [x] You have merged the latest changes from (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number

- [x] Automated checks pass.

#### Process Checks

- [x] You have specified at least one "Reviewer".

