### PR TITLE
SRCH-6457: Remove i14y from local dev stack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ jobs:
             sudo mkdir -m 777 /workspace
             cd ~/workspace
             git clone https://github.com/GSA/search-gov.git
-            git clone https://github.com/GSA/i14y.git
             git clone https://github.com/GSA-TTS/searchgov-spider.git
             cd ~/workspace/search-services
 

--- a/Dockerfile.elasticsearch7
+++ b/Dockerfile.elasticsearch7
@@ -1,6 +1,6 @@
 # searchgov/elasticsearch:7.17.7
 FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.7
-# The following plugins are required for multilingual support in i14y
+# The following plugins are required for multilingual search support
 RUN elasticsearch-plugin install analysis-kuromoji
 RUN elasticsearch-plugin install analysis-icu
 RUN elasticsearch-plugin install analysis-smartcn

--- a/Dockerfile.elasticsearch8
+++ b/Dockerfile.elasticsearch8
@@ -1,6 +1,0 @@
-# searchgov/elasticsearch:8.5.3
-FROM docker.elastic.co/elasticsearch/elasticsearch:8.5.3
-# The following plugins are required for multilingual support in i14y
-RUN elasticsearch-plugin install analysis-kuromoji
-RUN elasticsearch-plugin install analysis-icu
-RUN elasticsearch-plugin install analysis-smartcn

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ This repo includes a centralized configuration for services used by Search.gov a
 
 - [search-gov](https://github.com/GSA/search-gov)
 - [spider](https://github.com/GSA-TTS/searchgov-spider)
-- [i14y](https://github.com/GSA/i14y)
 
 ## Prerequisites
 In order to run the services, you will need to install [Docker](https://www.docker.com/get-started).  We recommend setting the max memory alloted to Docker to 4GB (in Docker Desktop, Preferences > Resources > Advanced). See [the wiki](https://github.com/GSA/search-services/wiki/Docker-Command-Reference) for more documentation on basic Docker commands.
@@ -15,7 +14,7 @@ The docker-compose.yml file configures each service. You can refer to [Matrix](h
 | Application/Repo | Command | Profile name | Services |
 | --- | --- | --- | --- |
 |  | `docker compose up` | N/A | MySQL, Elasticsearch, Kibana, Redis, OpenSearch, OpenSearch Dashboards |
-| search-gov |`docker compose --profile search-gov up` | search-gov | MySQL, Elasticsearch, Kibana, Redis, OpenSearch, OpenSearch Dashboards, search-gov, i14y, resque-workers, resque-scheduler, spider, spider-scheduler, spider-sitemap |
+| search-gov |`docker compose --profile search-gov up` | search-gov | MySQL, Elasticsearch, Kibana, Redis, OpenSearch, OpenSearch Dashboards, search-gov, resque-workers, resque-scheduler, spider, spider-scheduler, spider-sitemap |
 
 Alternatively, you can run a subset of the services, i.e.:
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     volumes:
       - es_7_data:/usr/share/elasticsearch/data
     ports:
-      - 9200:9200
+      - ${ES7_PORT:-9201}:9200
     expose:
       - 9200
     healthcheck:
@@ -88,7 +88,7 @@ services:
   redis:
     image: redis:6.2
     ports:
-      - 6379:6379
+      - 6381:6379
     networks:
       - app-network
     command: redis-server --bind "0.0.0.0"
@@ -155,7 +155,7 @@ services:
     expose:
       - 3000
     ports:
-      - 3000:3000
+      - ${SEARCH_GOV_PORT:-3000}:3000
 
   resque-workers:
     <<: *search-gov-base
@@ -164,37 +164,6 @@ services:
   resque-scheduler:
     <<: *search-gov-base
     command: bin/bundle exec rake resque:scheduler
-
-  i14y:
-    build:
-      context: ../i14y/
-      dockerfile: Dockerfile.dev
-    depends_on:
-      - elasticsearch7
-      - kibana7
-      - mysql
-      - redis
-    command: bin/rails server --binding 0.0.0.0 -p 3200
-    environment:
-      - ES_HOSTS=elasticsearch7:9200
-      - PIDFILE=/tmp/pids/server.pid
-      - DOCKER=true
-    expose:
-      - 3200
-    tmpfs:
-      - /tmp/pids/
-    ports:
-      - 3200:3200
-    volumes:
-      - ../i14y/:/usr/src/app
-      - ../i14y/config/secrets.yml:/usr/src/app/config/secrets.yml
-      - gem_cache_i14y:/gems
-    links:
-      - elasticsearch7
-    networks:
-      - app-network
-    profiles:
-      - search-gov
 
   spider: &spider
     build:
@@ -230,7 +199,6 @@ volumes:
   db_data:
   es_7_data:
   opensearch_data:
-  gem_cache_i14y:
   gem_cache_search-gov:
 
 networks:


### PR DESCRIPTION
## Summary

- Remove i14y service and gem_cache_i14y volume from docker-compose.yml
- Delete unused Dockerfile.elasticsearch8
- Update Dockerfile.elasticsearch7 comment (generic, not i14y-specific)
- Remove i14y from README services list
- Remove i14y git clone from CircleCI config

## Test plan

- [ ] `docker compose config --quiet` passes
- [ ] `docker compose up` starts remaining services without error